### PR TITLE
Support JDK EA builds in JavaVersionDetector

### DIFF
--- a/awaitility/src/main/java/org/awaitility/core/JavaVersionDetector.java
+++ b/awaitility/src/main/java/org/awaitility/core/JavaVersionDetector.java
@@ -14,6 +14,8 @@ public final class JavaVersionDetector {
             normalizedJavaVersion = "8";
         } else if (javaVersion.startsWith("1.")) {
             normalizedJavaVersion = javaVersion.substring(2, 3);
+        } else if (javaVersion.endsWith("-ea")) {
+            normalizedJavaVersion = javaVersion.substring(0, javaVersion.length() - 3);
         } else {
             int dot = javaVersion.indexOf(".");
             if (dot != -1) {

--- a/awaitility/src/main/java/org/awaitility/core/JavaVersionDetector.java
+++ b/awaitility/src/main/java/org/awaitility/core/JavaVersionDetector.java
@@ -4,18 +4,22 @@ public final class JavaVersionDetector {
     private static final String JAVA_VERSION = System.getProperty("java.version");
 
     public static int getJavaMajorVersion() {
+        return getJavaMajorVersion(JAVA_VERSION);
+    }
+
+    static int getJavaMajorVersion(String javaVersion) {
         final String normalizedJavaVersion;
-        if (JAVA_VERSION == null || JAVA_VERSION.isEmpty()) {
+        if (javaVersion == null || javaVersion.isEmpty()) {
             // Fallback to java 8
             normalizedJavaVersion = "8";
-        } else if (JAVA_VERSION.startsWith("1.")) {
-            normalizedJavaVersion = JAVA_VERSION.substring(2, 3);
+        } else if (javaVersion.startsWith("1.")) {
+            normalizedJavaVersion = javaVersion.substring(2, 3);
         } else {
-            int dot = JAVA_VERSION.indexOf(".");
+            int dot = javaVersion.indexOf(".");
             if (dot != -1) {
-                normalizedJavaVersion = JAVA_VERSION.substring(0, dot);
+                normalizedJavaVersion = javaVersion.substring(0, dot);
             } else {
-                normalizedJavaVersion = JAVA_VERSION;
+                normalizedJavaVersion = javaVersion;
             }
         }
         return Integer.parseInt(normalizedJavaVersion);

--- a/awaitility/src/test/java/org/awaitility/core/JavaVersionDetectorTest.java
+++ b/awaitility/src/test/java/org/awaitility/core/JavaVersionDetectorTest.java
@@ -1,0 +1,75 @@
+package org.awaitility.core;
+
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+public class JavaVersionDetectorTest {
+
+    @Test
+    public void nullJavaVersionDefaultsTo8() {
+        assertThat(JavaVersionDetector.getJavaMajorVersion(null), equalTo(8));
+    }
+
+    @Test
+    public void emptyJavaVersionDefaultsTo8() {
+        assertThat(JavaVersionDetector.getJavaMajorVersion(""), equalTo(8));
+    }
+
+    @Test
+    public void javaVersionFor8() {
+        /*
+        docker run --rm -it eclipse-temurin:8-jdk bash
+        echo 'class Scratch {
+            public static void main(String[] args) {
+                System.out.println(System.getProperty("java.version"));
+            }
+        }' > Scratch.java
+        javac Scratch.java
+        java -cp . Scratch
+        */
+        assertThat(JavaVersionDetector.getJavaMajorVersion("1.8.0_402"), equalTo(8));
+    }
+
+    @Test
+    public void javaVersionFor11WithDot() {
+        /*
+        docker run --rm -it eclipse-temurin:11-jdk jshell
+        System.getProperty("java.version")
+         */
+        assertThat(JavaVersionDetector.getJavaMajorVersion("11.0.22"), equalTo(11));
+    }
+
+    @Test
+    public void javaVersionFor17WithDot() {
+        /*
+        docker run --rm -it eclipse-temurin:17-jdk jshell
+        System.getProperty("java.version")
+         */
+        assertThat(JavaVersionDetector.getJavaMajorVersion("17.0.10"), equalTo(17));
+    }
+
+    @Test
+    public void javaVersionFor21WithoutDot() {
+        /*
+        Until there is a first patch release, java.version reports a single number without dots.
+         */
+        assertThat(JavaVersionDetector.getJavaMajorVersion("21"), equalTo(21));
+    }
+
+    @Test
+    public void javaVersionFor21WithDot() {
+        /*
+        docker run --rm -it eclipse-temurin:21-jdk jshell
+        System.getProperty("java.version")
+         */
+        assertThat(JavaVersionDetector.getJavaMajorVersion("21.0.2"), equalTo(21));
+    }
+
+    @Test
+    public void javaVersionFor23ea() {
+        assertThat(JavaVersionDetector.getJavaMajorVersion("23-ea"), equalTo(23));
+    }
+
+}


### PR DESCRIPTION
The (current) scheme for JDK EA builds is `<major>-ea`.

The first commit extracts `getJavaMajorVersion(String)` to make it testable.
The second commit adds test cases for version string for the current LTS builds and the EA build (the EA test case fails).
The third commit adds EA detection and fixes the EA test case.

This PR should close #275 and #277.